### PR TITLE
fix(savedebdiff): Raise more specific exceptions

### DIFF
--- a/savedebdiff
+++ b/savedebdiff
@@ -29,12 +29,16 @@ LOG_FORMAT = "%(name)s %(levelname)s: %(message)s"
 __script_name__ = os.path.basename(sys.argv[0]) if __name__ == "__main__" else __name__
 
 
+class ChangelogNotFoundError(Exception):
+    """debian/changelog not found."""
+
+
 def find_debian_changelog(debdiff: unidiff.PatchSet) -> unidiff.PatchedFile:
     """Find debian/changelog in given debdiff."""
     for modified_file in debdiff.added_files + debdiff.modified_files:
         if modified_file.path.endswith("debian/changelog"):
             return modified_file
-    raise Exception("No debian/changelog found in debdiff.")
+    raise ChangelogNotFoundError("No debian/changelog found in debdiff.")
 
 
 def derive_filename_from_debdiff(debdiff: unidiff.PatchSet) -> str:
@@ -48,7 +52,7 @@ def derive_filename_from_debdiff(debdiff: unidiff.PatchSet) -> str:
         source = match.group(1)
         version = match.group(2)
         return f"{source}_{version}.debdiff"
-    raise Exception(f"Failed to extract source and version from debian/changelog diff:\n{hunk}")
+    raise ValueError(f"Failed to extract source and version from debian/changelog diff:\n{hunk}")
 
 
 def save_debdiff(filename: str, debdiff: str, force: bool) -> None:

--- a/tests/test_savedebdiff.py
+++ b/tests/test_savedebdiff.py
@@ -22,7 +22,12 @@ import unittest.mock
 
 import unidiff
 
-from .scripts.savedebdiff import derive_filename_from_debdiff, main, save_debdiff
+from .scripts.savedebdiff import (
+    ChangelogNotFoundError,
+    derive_filename_from_debdiff,
+    main,
+    save_debdiff,
+)
 
 LIBEVENT_DEBDIFF = """\
 diff -Nru libevent-2.1.12-stable/debian/changelog libevent-2.1.12-stable/debian/changelog
@@ -89,9 +94,7 @@ class TestSavedebdiff(unittest.TestCase):
 
     def test_debian_changelog_not_found(self):
         empty = unidiff.PatchSet("")
-        self.assertRaisesRegex(
-            Exception, "No debian/changelog found", derive_filename_from_debdiff, empty
-        )
+        self.assertRaises(ChangelogNotFoundError, derive_filename_from_debdiff, empty)
 
     @unittest.mock.patch("sys.stdin")
     def test_main(self, stdin_mock):

--- a/tests/test_savedebdiff.py
+++ b/tests/test_savedebdiff.py
@@ -56,6 +56,20 @@ diff -Nru libevent-2.1.12-stable/debian/control libevent-2.1.12-stable/debian/co
  Priority: optional
  Build-Depends: debhelper-compat (= 13),
 """
+MISSING_VERSION_DEBDIFF = """\
+diff -Nru apport-2.23.1-0ubuntu3.1/debian/changelog apport-2.23.1-0ubuntu3.2/debian/changelog
+--- apport-2.23.1-0ubuntu3.1/debian/changelog	2023-04-12 11:24:37.000000000 +0200
++++ apport-2.23.1-0ubuntu3.2/debian/changelog	2023-04-12 12:38:24.000000000 +0200
+@@ -3,8 +3,6 @@
+   * Let apport depend on recent python3-problem-report for recent bug fix
+   * SECURITY UPDATE: viewing an apport-cli crash with default pager could
+     escalate privilege (LP: #2016023)
+-    - d/p/refactor-Introduce-run_as_real_user.patch: Introduce
+-      run_as_real_user()
+     - d/p/fix-Only-open-browser-as-user-via-sudo-if-running-as-root.patch:
+       Only open browser as user (via sudo) if running as root
+     - d/p/Replace-sudo-by-dropping-privileges-ourselves.patch: Replace sudo by
+"""
 UPDATE_MANAGER_DEBDIFF = """\
 diff -Nru update-manager-22.10.7/debian/changelog update-manager-23.04.1/debian/changelog
 --- update-manager-22.10.7/debian/changelog	2023-02-02 04:07:52.000000000 +0100
@@ -87,6 +101,10 @@ class TestSavedebdiff(unittest.TestCase):
     def test_derive_filename_from_debdiff(self):
         filename = derive_filename_from_debdiff(unidiff.PatchSet(LIBEVENT_DEBDIFF))
         self.assertEqual(filename, "libevent_2.1.12-stable-5ubuntu1.debdiff")
+
+    def test_derive_filename_from_debdiff_missing_version(self):
+        missing_version = unidiff.PatchSet(MISSING_VERSION_DEBDIFF)
+        self.assertRaises(ValueError, derive_filename_from_debdiff, missing_version)
 
     def test_derive_filename_from_debdiff_with_epoch(self):
         filename = derive_filename_from_debdiff(unidiff.PatchSet(UPDATE_MANAGER_DEBDIFF))


### PR DESCRIPTION
pylint 2.16.2 complains:

```
************* Module savedebdiff
savedebdiff:37:4: W0719: Raising too general exception: Exception (broad-exception-raised)
savedebdiff:51:4: W0719: Raising too general exception: Exception (broad-exception-raised)
```

So raise more specific exceptions.