### PR TITLE
ci: Add Debian 12 "Bookworm"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          - debian:bookworm-slim
           - debian:testing-slim
           - debian:unstable-slim
           - ubuntu:jammy


### PR DESCRIPTION
Debian 12 "Bookworm" will become `stable` soon.