### PR TITLE
ci: Drop Ubuntu 22.10 "Kinetic Kudu"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ jobs:
           - debian:testing-slim
           - debian:unstable-slim
           - ubuntu:jammy
-          - ubuntu:kinetic
           - ubuntu:lunar
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
Ubuntu 22.10 "Kinetic Kudu" is end-of-life.