### PR TITLE
schroot-wrapper: read version codename from /etc/os-release

### DIFF
--- a/schroot-wrapper
+++ b/schroot-wrapper
@@ -107,6 +107,19 @@ class SchrootSession:
         )
         return process.stdout.strip()
 
+    def get_version_codename(self) -> str:
+        """Return VERSION_CODENAME from /etc/os-release in the chroot."""
+        process = self.run(
+            "/",
+            "root",
+            ["sh", "-c", '. /etc/os-release && echo "$VERSION_CODENAME"'],
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+        )
+        version_codename = process.stdout.strip()
+        assert re.match("^[a-z]+$", version_codename)
+        return version_codename
+
     def create_directory(self, directory: str, owner: str) -> None:
         """Create the directory in the chroot."""
         self.run("/", "root", ["install", "-d", "-o", owner, directory])
@@ -120,7 +133,7 @@ class SchrootSession:
         sources = (
             f"Types: deb\n"
             f"URIs: {' '.join(uris)}\n"
-            f"Suites: {self.chroot}-proposed\n"
+            f"Suites: {self.get_version_codename()}-proposed\n"
             f"Components: {' '.join(components)}\n"
         )
         cmd = ["sh", "-c", f"printf '{sources}' > /etc/apt/sources.list.d/ubuntu-proposed.sources"]

--- a/tests/test_schroot_wrapper.py
+++ b/tests/test_schroot_wrapper.py
@@ -172,6 +172,11 @@ class TestSchrootWrapper(unittest.TestCase):
             RunMock(["schroot", "-c", "focal", "-b"], 0, "session-id\n"),
             RunMock(root_call + ["test", "-d", "/root"], 0),
             RunMock(
+                root_call + ["sh", "-c", '. /etc/os-release && echo "$VERSION_CODENAME"'],
+                0,
+                "focal\n",
+            ),
+            RunMock(
                 root_call
                 + [
                     "sh",


### PR DESCRIPTION
If the schroot is differently named than the version codename, `--enable-proposed` will use the wrong codename.

Read the version codename from `/etc/os-release` to not rely on naming the chroot after the codename.